### PR TITLE
globalStorage에 저장된 내용 가져오기

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       {
         "command": "todo-note.addNote",
         "title": "Add note"
+      },
+      {
+        "command": "todo-note.refreshNote",
+        "title": "Refresh note"
       }
     ]
   },

--- a/src/extension.js
+++ b/src/extension.js
@@ -8,7 +8,7 @@ import { TestTreeDataProvider } from "./test-tree-data-provider.js";
  * @param {vscode.ExtensionContext} context
  */
 export function activate(context) {
-  const testTreeDataProvider = new TestTreeDataProvider();
+  const testTreeDataProvider = new TestTreeDataProvider(context);
 
   const addNoteCommand = vscode.commands.registerCommand(
     "todo-note.addNote",

--- a/src/extension.js
+++ b/src/extension.js
@@ -12,7 +12,10 @@ export function activate(context) {
 
   const addNoteCommand = vscode.commands.registerCommand(
     "todo-note.addNote",
-    () => addNote(context)
+    async () => {
+      await addNote(context);
+      testTreeDataProvider.refresh();
+    }
   );
   const refreshNoteCommand = vscode.commands.registerCommand(
     "todo-note.refreshNote",

--- a/src/extension.js
+++ b/src/extension.js
@@ -8,17 +8,23 @@ import { TestTreeDataProvider } from "./test-tree-data-provider.js";
  * @param {vscode.ExtensionContext} context
  */
 export function activate(context) {
+  const testTreeDataProvider = new TestTreeDataProvider();
+
   const addNoteCommand = vscode.commands.registerCommand(
     "todo-note.addNote",
     () => addNote(context)
   );
-
-  const testTreeDataProvider = vscode.window.registerTreeDataProvider(
-    "todo-note-view",
-    new TestTreeDataProvider()
+  const refreshNoteCommand = vscode.commands.registerCommand(
+    "todo-note.refreshNote",
+    () => testTreeDataProvider.refresh()
   );
 
-  context.subscriptions.push(addNoteCommand, testTreeDataProvider);
+  const testTree = vscode.window.registerTreeDataProvider(
+    "todo-note-view",
+    testTreeDataProvider
+  );
+
+  context.subscriptions.push(addNoteCommand, refreshNoteCommand, testTree);
 }
 
 export function deactivate() {}

--- a/src/test-tree-data-provider.js
+++ b/src/test-tree-data-provider.js
@@ -1,39 +1,24 @@
 import vscode from "./vscode-module.js";
+import { join } from "path";
+import { readFile } from "fs/promises";
 
 export class TestTreeDataProvider {
-  constructor() {
+  constructor(context) {
     this._onDidChangeTreeData = new vscode.EventEmitter();
     this.onDidChangeTreeData = this._onDidChangeTreeData.event;
+    this.context = context;
   }
 
   getTreeItem(element) {
     return element;
   }
 
-  getChildren(element) {
+  async getChildren(element) {
     if (!element) {
-      return [
-        new vscode.TreeItem(
-          "Parent 1",
-          vscode.TreeItemCollapsibleState.Collapsed
-        ),
-        new vscode.TreeItem(
-          "Parent 2",
-          vscode.TreeItemCollapsibleState.Collapsed
-        ),
-      ];
-    } else if (element.label === "Parent 1") {
-      return [
-        new vscode.TreeItem("Child 1-1"),
-        new vscode.TreeItem("Child 1-2"),
-      ];
-    } else if (element.label === "Parent 2") {
-      return [
-        new vscode.TreeItem("Child 2-1"),
-        new vscode.TreeItem("Child 2-2"),
-      ];
+      const filePath = join(this.context.globalStorageUri.fsPath, "note");
+      const content = await readFile(filePath);
+      return [new vscode.TreeItem(content.toString())];
     }
-    return [];
   }
 
   refresh() {

--- a/src/test-tree-data-provider.js
+++ b/src/test-tree-data-provider.js
@@ -2,13 +2,22 @@ import vscode from "./vscode-module.js";
 import { join } from "path";
 import { readFile } from "fs/promises";
 
+/**
+ * @implements {vscode.TreeDataProvider}
+ */
 export class TestTreeDataProvider {
+  /**
+   * @param {vscode.ExtensionContext} context
+   */
   constructor(context) {
     this._onDidChangeTreeData = new vscode.EventEmitter();
     this.onDidChangeTreeData = this._onDidChangeTreeData.event;
     this.context = context;
   }
 
+  /**
+   * @returns {vscode.TreeItem}
+   */
   getTreeItem(element) {
     return element;
   }

--- a/src/test-tree-data-provider.js
+++ b/src/test-tree-data-provider.js
@@ -1,6 +1,11 @@
 import vscode from "./vscode-module.js";
 
 export class TestTreeDataProvider {
+  constructor() {
+    this._onDidChangeTreeData = new vscode.EventEmitter();
+    this.onDidChangeTreeData = this._onDidChangeTreeData.event;
+  }
+
   getTreeItem(element) {
     return element;
   }
@@ -29,5 +34,9 @@ export class TestTreeDataProvider {
       ];
     }
     return [];
+  }
+
+  refresh() {
+    this._onDidChangeTreeData.fire();
   }
 }


### PR DESCRIPTION
readFile을 사용해서 globalStorage에 저장된 내용을 가져온다.

vscode.EventEmitter를 만들어 이벤트 발생 시 트리 내용을 다시 가져오도록 한다.

새로고침 기능을 사용해 Add note로 저장된 내용을 수정할 때, 저장한 내용을 업데이트할 수 있다.